### PR TITLE
Fix nav links from privacy page

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,10 +2,19 @@ import "./src/styles/global.css";
 import React from "react";
 import RootElement from "./src/components/root-element";
 
-export const onRenderBody = ({ setHtmlAttributes }) => {
-  setHtmlAttributes({ lang: "en" });
-};
-
 export const wrapRootElement = ({ element }) => {
   return <RootElement>{element}</RootElement>;
 };
+
+export const onRouteUpdate = ({ location }) => {
+  if (location.hash === '#top') {
+    // NOTE: We add this in order to allow linking to the #top of a page
+    //       without this being persisted as the location in browser history.
+    //       This allows for the link to the top to always work, even if
+    //       a saved scroll position exists for the page, while also allowing
+    //       for the user to then scroll around the page, click to somewhere
+    //       else, and then navigate back and come back to their previous scroll
+    //       position.
+    window.history.replaceState({}, "", location.pathname)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "gatsby-transformer-json": "^5.13.1",
         "gatsby-transformer-sharp": "^5.13.1",
         "react": "^18.2.0",
-        "react-anchor-link-smooth-scroll": "^1.0.12",
         "react-dom": "^18.2.0",
         "react-modal": "3.16.1",
         "sanitize-html": "2.13.0",
@@ -16955,11 +16954,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-anchor-link-smooth-scroll": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/react-anchor-link-smooth-scroll/-/react-anchor-link-smooth-scroll-1.0.12.tgz",
-      "integrity": "sha512-aaY+9X0yh8YnC0jBfoTKpsiCLdO/Y6pCltww+VB+NnTBPDOvnIdnp1AlazajsDitc1j+cVSQ+yNtaVeTIMQbxw=="
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "gatsby-transformer-json": "^5.13.1",
     "gatsby-transformer-sharp": "^5.13.1",
     "react": "^18.2.0",
-    "react-anchor-link-smooth-scroll": "^1.0.12",
     "react-dom": "^18.2.0",
     "sass": "^1.55.0",
     "sanitize-html": "2.13.0",

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -8,7 +8,7 @@ const Header = ({ className = "" }) => (
       className={`${className} flex flex-col sm:flex-row justify-between items-center py-4`}
     >
       <a
-        href="/"
+        href="/#top"
         className="flex flex-grow items-center font-serif font-black italic text-thimble hover:text-thimble lowercase text-4xl"
       >
         Thimble

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,5 +1,5 @@
 import React from "react";
-import AnchorLink from "react-anchor-link-smooth-scroll";
+import { Link } from "gatsby";
 import ContactUsButton from "../ContactUsButton";
 
 const Header = ({ className = "" }) => (
@@ -14,18 +14,18 @@ const Header = ({ className = "" }) => (
         Thimble
       </a>
       <div className="flex items-center mt-4 sm:mt-0 flex-row gap-4">
-        <AnchorLink
+        <Link
           className="text-black hover:text-thimble"
-          href="#approach"
+          href="/#approach"
         >
           Approach
-        </AnchorLink>
-        <AnchorLink
+        </Link>
+        <Link
           className="text-black hover:text-thimble"
-          href="#services"
+          href="/#services"
         >
           Services
-        </AnchorLink>
+        </Link>
         <div className="hidden md:block">
           <ContactUsButton className="text-sm">
             Contact Us

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,10 @@ a:hover {
   @apply text-weblink-blue-darker;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 section:before {
   content: '';
   display: block;


### PR DESCRIPTION
Fixes header links working from non-home page:

https://github.com/user-attachments/assets/069bf685-b4a3-4818-aee1-85199735c54a

Also removes an now-unnecessary js package

# Oddities with Scroll Position

I learned when making this change that there was some odd behaviour with scroll position happening. Essentially, clicking on the Thimble logo to navigate back to the top of the page wasn't working on the home page.

The reason is that Gatsby does do some work to save the last scroll position and navigate to it on next visits to that page. I think it doesn't take into account that, in the case of a link to `"/"`, I do want this to scroll to the top. Instead, if it sees a last saved scroll position for that page, it loads that.

I tried a few different solutions. The one I settled on is:

1. Have the home page link have a `#top` anchor tag in it
2. Add in a little bit of code that runs when routing happens, to remove that from the visible address to the user.

This allows me to ensure links to the top of the page always go there, while allowing browser forward/back navigations to keep scrolling to last saved positions.

Scroll to top by clicking the header link working fine:

https://github.com/user-attachments/assets/c9cde6c2-1105-47c4-8622-3a97bec1db90


Example of scrolling down, going to a different page, and then clicking to go back to a previous page still going to the last saved scroll position:

https://github.com/user-attachments/assets/0ca05b6a-bbd2-4964-b91b-cbd84c3ebafd



